### PR TITLE
feat: implement multiple team support in CLI and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v2.3] - 2025-10-28
+
+### Added
+- **Multiple Team Support**: Enhanced PR search functionality to support searching across one or more teams simultaneously
+  - Accept comma-separated team names via `--team` flag (e.g., `--team org/team1,org/team2`)
+  - Support multiple teams in YAML configuration and environment variables
+  - Automatically deduplicate repositories when teams share common repos
+  - Maintain backward compatibility with single team usage
+
+### Changed
+- Updated internal configuration structure to handle team arrays instead of single team strings
+- Modified GitHub API client to aggregate repositories from multiple teams
+- Enhanced CLI flag descriptions to indicate multiple team support

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -265,7 +266,7 @@ func configsEqual(a, b *Config) bool {
 
 	return a.GitHubToken == b.GitHubToken &&
 		a.Org == b.Org &&
-		a.Team == b.Team &&
+		reflect.DeepEqual(a.Team, b.Team) &&
 		a.User == b.User &&
 		a.Repo == b.Repo &&
 		a.Since == b.Since &&

--- a/internal/gh/client_test.go
+++ b/internal/gh/client_test.go
@@ -92,7 +92,7 @@ func TestMockClient_ListRepos(t *testing.T) {
 		{
 			name: "valid team scope",
 			scope: &config.Config{
-				Team: "org/team",
+				Team: []string{"org/team"},
 			},
 			mockRepos: []*github.Repository{
 				{Name: github.String("team-repo")},

--- a/internal/gh/mock.go
+++ b/internal/gh/mock.go
@@ -64,7 +64,7 @@ func (m *MockClient) ListRepos(scope *config.Config) ([]*github.Repository, erro
 	if scope.Repo != "" {
 		scopeCount++
 	}
-	if scope.Team != "" {
+	if len(scope.Team) > 0 {
 		scopeCount++
 	}
 

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -26,7 +26,7 @@ func ResolveRepos(cfg *config.Config, ghClient gh.GitHubClient) ([]string, error
 		scopeCount++
 		scopeType = "org"
 	}
-	if cfg.Team != "" {
+	if len(cfg.Team) > 0 {
 		scopeCount++
 		scopeType = "team"
 	}
@@ -84,7 +84,7 @@ func ValidateScope(cfg *config.Config) error {
 		scopeCount++
 		scopes = append(scopes, "org")
 	}
-	if cfg.Team != "" {
+	if len(cfg.Team) > 0 {
 		scopeCount++
 		scopes = append(scopes, "team")
 	}

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -60,7 +60,7 @@ func TestResolveRepos(t *testing.T) {
 		{
 			name: "valid team scope",
 			cfg: &config.Config{
-				Team: "org/team",
+				Team: []string{"org/team"},
 			},
 			mockRepos: []*github.Repository{
 				{FullName: github.String("org/team-repo1")},
@@ -215,7 +215,7 @@ func TestValidateScope(t *testing.T) {
 		{
 			name: "valid team scope",
 			cfg: &config.Config{
-				Team: "org/team",
+				Team: []string{"org/team"},
 			},
 			expectError: false,
 		},
@@ -244,7 +244,7 @@ func TestValidateScope(t *testing.T) {
 			name: "all scopes should return error",
 			cfg: &config.Config{
 				Org:  "test-org",
-				Team: "org/team",
+				Team: []string{"org/team"},
 				User: "test-user",
 				Repo: "owner/repo",
 			},


### PR DESCRIPTION
- Enhanced PR search functionality to support multiple teams via comma-separated input.
- Updated configuration to handle team lists as slices.
- Modified GitHub API client to aggregate repositories from multiple teams.
- Improved tests to validate new team handling.